### PR TITLE
feat: serial queries, including mutations

### DIFF
--- a/example/simple/simple.go
+++ b/example/simple/simple.go
@@ -57,7 +57,7 @@ func (r *PersonResolver) Name() string {
 }
 
 func main() {
-	server, err := magellan.ParseSchema(schemaSrc, &RootQueryResolver{})
+	server, err := magellan.ParseSchema(schemaSrc, &RootQueryResolver{}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/resolve/resolve_chan.go
+++ b/resolve/resolve_chan.go
@@ -44,6 +44,10 @@ func (cv *chanValueResolver) Execute(rc *resolutionContext, value reflect.Value)
 }
 
 func (rt *ResolverTree) buildChanValueResolver(value reflect.Type, gtyp *ast.Named) (Resolver, error) {
+	if rt.SerialOnly {
+		return nil, fmt.Errorf("Cannot accept non-immediate result in mutations (at %s, mutations cannot return deferred values).", value.String())
+	}
+
 	if value.ChanDir() != reflect.RecvDir {
 		return nil, fmt.Errorf("Invalid live-value type %s, (should be a %v, is a %v)", value.String(), reflect.RecvDir, value.ChanDir())
 	}

--- a/resolve/resolve_enum.go
+++ b/resolve/resolve_enum.go
@@ -50,7 +50,11 @@ func (er *enumResolver) Execute(rc *resolutionContext, value reflect.Value) {
 		}
 	}
 
-	go er.valueResolver.Execute(rc, value)
+	if rc.isSerial {
+		er.valueResolver.Execute(rc, value)
+	} else {
+		go er.valueResolver.Execute(rc, value)
+	}
 }
 
 func (rt *ResolverTree) buildEnumResolver(value reflect.Type, etyp *ast.EnumDefinition) (Resolver, error) {

--- a/resolve/test/resolve_test.go
+++ b/resolve/test/resolve_test.go
@@ -20,12 +20,17 @@ type Person {
 	parents: [String]
 }
 
+type RootMutation {
+	addPerson(name: String): Person
+}
+
 type RootQuery {
 	allPeople: [Person]
 }
 
 schema {
 	query: RootQuery
+	mutation: RootMutation
 }
 `
 
@@ -38,7 +43,31 @@ allPeople {
 type RootQueryResolver struct{}
 
 func (*RootQueryResolver) AllPeople(ctx context.Context) []*PersonResolver {
-	return []*PersonResolver{{errorOut: true}, {}}
+	return []*PersonResolver{{}, {}}
+}
+
+type RootMutationResolver struct{}
+
+func (r *RootMutationResolver) AddPerson(args *struct{ Name string }) *StaticPersonResolver {
+	return &StaticPersonResolver{
+		name: args.Name,
+	}
+}
+
+type StaticPersonResolver struct {
+	name string
+}
+
+func (sp *StaticPersonResolver) GetName() string {
+	return sp.name
+}
+
+func (r *StaticPersonResolver) GetSteps() uint16 {
+	return 0
+}
+
+func (r *StaticPersonResolver) GetParents() []string {
+	return nil
 }
 
 type PersonResolver struct {
@@ -92,43 +121,47 @@ func (r *PersonResolver) Parents() <-chan <-chan string {
 	return outp
 }
 
-func buildMockTree(t *testing.T) (*schema.Schema, *qtree.QueryTreeNode) {
+func buildMockTree(t *testing.T, addChildren bool, isMutation bool) (*schema.Schema, *qtree.QueryTreeNode) {
 	sch, err := schema.Parse(schemaSrc)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	qt, err := sch.BuildQueryTree()
+	sendCh := make(chan *proto.RGQLQueryError, 1)
+	qt, err := sch.BuildQueryTree(sendCh, isMutation)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	err = qt.AddChild(&proto.RGQLQueryTreeNode{
-		Id:        1,
-		FieldName: "allPeople",
-		Children: []*proto.RGQLQueryTreeNode{
-			{
-				Id:        2,
-				FieldName: "name",
+	if addChildren {
+		err = qt.AddChild(&proto.RGQLQueryTreeNode{
+			Id:        1,
+			FieldName: "allPeople",
+			Children: []*proto.RGQLQueryTreeNode{
+				{
+					Id:        2,
+					FieldName: "name",
+				},
+				{
+					Id:        3,
+					FieldName: "parents",
+				},
 			},
-			{
-				Id:        3,
-				FieldName: "parents",
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err.Error())
+		})
+		if err != nil {
+			t.Fatal(err.Error())
+		}
 	}
 	return sch, qt
 }
 
 func TestBasics(t *testing.T) {
-	schema, qt := buildMockTree(t)
+	schema, qt := buildMockTree(t, true, false)
 	rqr := &RootQueryResolver{}
-	if err := schema.SetResolvers(rqr); err != nil {
+	rmr := &RootMutationResolver{}
+	if err := schema.SetResolvers(rqr, rmr); err != nil {
 		t.Fatal(err.Error())
 	}
 	fmt.Printf("Executing...\n")
-	q := schema.StartQuery(context.Background(), qt)
+	q := schema.StartQuery(context.Background(), qt, false)
 	_ = q
 	go func() {
 		msgs := q.Messages()
@@ -175,4 +208,54 @@ func TestBasics(t *testing.T) {
 	})
 	q.Cancel()
 	q.Wait()
+}
+
+func TestMutation(t *testing.T) {
+	schema, qt := buildMockTree(t, false, true)
+	rqr := &RootQueryResolver{}
+	rmr := &RootMutationResolver{}
+	if err := schema.SetResolvers(rqr, rmr); err != nil {
+		t.Fatal(err.Error())
+	}
+	fmt.Printf("Executing mutation...\n")
+	qt.ApplyTreeMutation(&proto.RGQLTreeMutation{
+		Variables: []*proto.ASTVariable{
+			{
+				Id:        0,
+				JsonValue: `"Testy"`,
+			},
+		},
+		NodeMutation: []*proto.RGQLTreeMutation_NodeMutation{
+			{
+				NodeId:    0,
+				Operation: proto.RGQLTreeMutation_SUBTREE_ADD_CHILD,
+				Node: &proto.RGQLQueryTreeNode{
+					Id:        1,
+					FieldName: "addPerson",
+					Args: []*proto.FieldArgument{
+						{
+							Name:       "name",
+							VariableId: 0,
+						},
+					},
+					Children: []*proto.RGQLQueryTreeNode{
+						{
+							Id:        1,
+							FieldName: "name",
+						},
+					},
+				},
+			},
+		},
+	})
+	exc := schema.StartMutation(context.Background(), qt)
+	result, err := exc.Wait()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	bin, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Log(string(bin))
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"context"
-	"fmt"
 	"testing"
 )
 
@@ -68,7 +67,7 @@ func TestBuildSchema(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	err = schema.SetResolvers(&RootQueryResolver{})
+	err = schema.SetResolvers(&RootQueryResolver{}, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}


### PR DESCRIPTION
This commit adds support for serial operations, like mutations.

Serial operations pair a single request to a single response. They also forbid the use of live resolvers, as a full result is built before the response is sent.